### PR TITLE
fix(payloadcms-theme-management): ThemePreviewField correct admin config path

### DIFF
--- a/packages/theme-management/src/fields/ThemePreviewField.tsx
+++ b/packages/theme-management/src/fields/ThemePreviewField.tsx
@@ -257,7 +257,8 @@ export default function ThemePreviewField(props: SelectFieldClientProps) {
   const { field, path } = props
   // If the plugin provided theme presets via admin config, prefer those; otherwise fallback to allThemePresets
   const baseThemePresets =
-    (field?.admin as unknown as { themePresets?: ThemePreset[] })?.themePresets ?? allThemePresets
+    (field?.admin?.custom as unknown as { themePresets?: ThemePreset[] })?.themePresets ??
+    allThemePresets
   const runtimeThemePresets = useMemo(() => {
     return (baseThemePresets as ThemePreset[]).reduce<Record<string, ThemePresetDefinition>>(
       (acc, preset) => {


### PR DESCRIPTION
### Summary

This PR fixes an issue with a custom `themePresets` value not being rendered by the `ThemePreviewField` component. The field config path has been corrected from `admin.themePresets` to `admin.custom.themePresets`.