### PR TITLE
feat(theme-management): native PayloadCMS 3 i18n (cs+en, extensible)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,4 +45,10 @@ tests/**/*.d.ts.map
 temp/
 *.log
 
+# Generated test/runtime caches
+jest_0/
+**/jest_[0-9]*/
+node-compile-cache/
+**/node-compile-cache/
+
 # packages/dev/*

--- a/packages/theme-management/README.md
+++ b/packages/theme-management/README.md
@@ -339,6 +339,7 @@ const tenantThemeConfiguration = await fetchThemeConfiguration({
 | `enableLogging`             | `boolean`                                            | `false`                      | Logs plugin actions                                |
 | `livePreview`               | `boolean \| ThemeManagementLivePreviewOptions`       | `true`                       | Live preview URL behavior                          |
 | `cacheRevalidation`         | `boolean \| ThemeManagementCacheRevalidationOptions` | auto (standalone default on) | Cache invalidation endpoint/tags/paths             |
+| `i18n`                      | `ThemeManagementI18nOptions`                         | `undefined`                  | Extend/override admin translations (see below)     |
 
 ### `livePreview` options
 
@@ -365,6 +366,32 @@ const tenantThemeConfiguration = await fetchThemeConfiguration({
 | `secret`      | `string`   | `undefined`                             |
 | `tags`        | `string[]` | `[global_{slug}]`                       |
 | `paths`       | `string[]` | `[]`                                    |
+
+## Internationalization (i18n)
+
+The plugin ships with **English (`en`)** and **Czech (`cs`)** translations and registers
+them into Payload's native `config.i18n` under the `theme-management` namespace. Field
+labels are localized out of the box and the dynamic admin UI follows the active admin
+language.
+
+Add languages or override individual strings via the `i18n` option (deep-merged over the
+built-ins; missing keys fall back to English):
+
+```ts
+import { de } from '@payloadcms/translations/languages/de'
+
+themeManagementPlugin({
+  i18n: {
+    translations: {
+      de: { tabLabel: 'Darstellung', ui: { lightMode: 'Heller Modus' } },
+      en: { tabLabel: 'Theme' }, // override a built-in string
+    },
+    supportedLanguages: { de }, // optional: register a brand-new admin language
+  },
+})
+```
+
+Full guide: [docs/TRANSLATIONS.md](./docs/TRANSLATIONS.md)
 
 ## Appearance Controls (v1.2.0)
 

--- a/packages/theme-management/docs/TRANSLATIONS.md
+++ b/packages/theme-management/docs/TRANSLATIONS.md
@@ -1,38 +1,78 @@
 # Translations / i18n
 
-This plugin ships with built-in English (`en`) and Czech (`cs`) translations.
+The plugin ships with built-in **English (`en`)** and **Czech (`cs`)** translations and
+integrates with Payload's native i18n system.
 
-## Extending translations
+## How it works
 
-Use `registerTranslations` to add or override translations at runtime. Translations will be deep-merged into existing keys and any missing keys will fall back to English defaults.
+There are two layers, both driven by the same built-in `en` / `cs` strings:
 
-Example:
+1. **Field schema labels** are defined as Payload localized label objects
+   (`{ en: '…', cs: '…' }`) directly on the fields, so the admin schema is localized
+   out of the box.
+2. **Dynamic admin UI strings** (theme preview, font picker, style presets, …) are
+   registered into Payload's native `config.i18n.translations` under the
+   `theme-management` namespace, and the client field components read the active admin
+   language through Payload's i18n context (`useTranslation`) — no `navigator` sniffing.
+
+When the plugin runs, it merges its translations into `config.i18n.translations`,
+following the official Payload plugin i18n pattern. Translations already present on your
+config win over the plugin defaults, so you can override any string.
+
+## Extending via plugin configuration
+
+Add new languages or override individual strings through the `i18n` plugin option.
+Each entry is deep-merged over the built-in translations, so you only provide the keys
+you want to change. Missing keys fall back to English.
 
 ```ts
-import { registerTranslations } from '@kilivi-dev/payloadcms-theme-management'
+import { themeManagementPlugin } from '@kilivi-dev/payloadcms-theme-management'
+// Bring real language packs only if you want the admin to offer a brand-new UI language
+import { de } from '@payloadcms/translations/languages/de'
 
-registerTranslations({
-  fr: {
-    tabLabel: 'Apparence',
-    preview: {
-      siteTitle: 'Votre site',
+themeManagementPlugin({
+  i18n: {
+    translations: {
+      // New language
+      de: {
+        tabLabel: 'Darstellung',
+        ui: { lightMode: 'Heller Modus', darkMode: 'Dunkler Modus' },
+      },
+      // Override a built-in string
+      en: { tabLabel: 'Theme' },
     },
+    // Optional: register a brand-new admin language with Payload
+    supportedLanguages: { de },
   },
 })
 ```
 
-## Runtime language detection
+## Using the translations in custom components
 
-The admin language is detected using `getAdminLanguage()` which checks:
+Inside client (`'use client'`) admin components, read the plugin strings with the
+provided hooks — they resolve the active Payload admin language automatically:
 
-1. `document.documentElement.lang`
-2. `navigator.language` (or `navigator.userLanguage` fallback)
-3. `en` (final fallback)
+```tsx
+'use client'
+import {
+  useThemeTranslations,
+  useThemeLanguage,
+} from '@kilivi-dev/payloadcms-theme-management/hooks/useThemeTranslations'
 
-If you need to force a language for admin UI tests or in a specific environment, set `document.documentElement.lang` early in your admin script.
+function MyField() {
+  const t = useThemeTranslations() // full translation object for the active language
+  const lang = useThemeLanguage() // e.g. 'cs'
+  return <span>{t.ui.lightMode}</span>
+}
+```
 
-## API
+## Programmatic API
 
-- `getTranslations(lang?: string): PluginTranslations` - Get translations for the provided language (fall back to English)
-- `registerTranslations(newTranslations: Record<string, Partial<PluginTranslations>>)` - Register or extend translations at runtime
-- `availableLanguages(): string[]` - List available registered languages
+Server-side / build-time helpers exported from the package root:
+
+- `getTranslations(lang?: string): PluginTranslations` — translations for a language (English fallback).
+- `registerTranslations(newTranslations)` — register or extend translations at runtime (deep-merged).
+- `availableLanguages(): string[]` — list registered languages.
+- `getThemeManagementI18nTranslations()` — translations in Payload's `config.i18n.translations` shape.
+- `mergeThemeManagementI18n(existing, options?)` — merge plugin translations into an existing `config.i18n`.
+- `THEME_MANAGEMENT_I18N_NAMESPACE` — the `'theme-management'` namespace constant.

--- a/packages/theme-management/package.json
+++ b/packages/theme-management/package.json
@@ -23,6 +23,10 @@
       "import": "./dist/fields/*.js",
       "types": "./dist/fields/*.d.ts"
     },
+    "./hooks/*": {
+      "import": "./dist/hooks/*.js",
+      "types": "./dist/hooks/*.d.ts"
+    },
     "./views/*": {
       "import": "./dist/views/*.js",
       "types": "./dist/views/*.d.ts"

--- a/packages/theme-management/src/fields/AppearancePreviewField.tsx
+++ b/packages/theme-management/src/fields/AppearancePreviewField.tsx
@@ -9,8 +9,8 @@ import {
   getDevicePreview,
   type DevicePreviewId,
 } from '../constants/devicePreviews.js'
+import { useThemeLanguage } from '../hooks/useThemeTranslations.js'
 import { borderRadiusPresets } from '../providers/Theme/themeConfig.js'
-import { getAdminLanguage } from '../utils/getAdminLanguage.js'
 
 const DEVICE_ICONS: Record<DevicePreviewId, LucideIcon> = {
   mobile: Smartphone,
@@ -255,7 +255,7 @@ export default function AppearancePreviewField() {
     string,
     { value?: unknown } | undefined
   >
-  const lang = getAdminLanguage() as 'en' | 'cs'
+  const lang = useThemeLanguage() as 'en' | 'cs'
   const [mode, setMode] = useState<Mode>('light')
   const [device, setDevice] = useState<DevicePreviewId>(DEFAULT_DEVICE_PREVIEW_ID)
   const uid = useId().replace(/[:]/g, '')

--- a/packages/theme-management/src/fields/FontSelectField.tsx
+++ b/packages/theme-management/src/fields/FontSelectField.tsx
@@ -3,8 +3,7 @@
 import { useField } from '@payloadcms/ui'
 import type { SelectFieldClientComponent } from 'payload'
 import { useEffect, useState } from 'react'
-import { getTranslations } from '../translations.js'
-import { getAdminLanguage } from '../utils/getAdminLanguage.js'
+import { useThemeLanguage, useThemeTranslations } from '../hooks/useThemeTranslations.js'
 
 type LocalizedLabel = Record<string, string>
 
@@ -18,6 +17,7 @@ interface FontOption {
 const FontSelectField: SelectFieldClientComponent = ({ field, path }) => {
   const { value, setValue } = useField<string>({ path })
   const [isOpen, setIsOpen] = useState(false)
+  const lang = useThemeLanguage()
 
   const options = (field.options as FontOption[]) || []
   const selectedOption = options.find((opt) => opt.value === value)
@@ -25,7 +25,6 @@ const FontSelectField: SelectFieldClientComponent = ({ field, path }) => {
 
   const getOptionLabel = (opt: FontOption) => {
     if (typeof opt.label === 'string') return opt.label
-    const lang = getAdminLanguage()
     return opt.label[lang] || opt.label.en || opt.label.cs || 'Font'
   }
 
@@ -73,12 +72,12 @@ const FontSelectField: SelectFieldClientComponent = ({ field, path }) => {
     }
   }, [isOpen])
 
-  const t = getTranslations(getAdminLanguage())
+  const t = useThemeTranslations()
   const label =
     typeof field.label === 'string'
       ? field.label
       : typeof field.label === 'object'
-        ? field.label?.en || field.label?.cs
+        ? field.label?.[lang] || field.label?.en || field.label?.cs
         : field.label || 'Font'
 
   return (

--- a/packages/theme-management/src/fields/StylePresetField.tsx
+++ b/packages/theme-management/src/fields/StylePresetField.tsx
@@ -3,9 +3,9 @@
 import { useField, useForm } from '@payloadcms/ui'
 import type { TextFieldClientProps } from 'payload'
 import { useCallback, useMemo } from 'react'
+import { useThemeLanguage, useThemeTranslations } from '../hooks/useThemeTranslations.js'
 import { allStylePresets, stylePresetCategories } from '../style-presets.js'
 import type { StylePreset } from '../style-presets.js'
-import { getAdminLanguage } from '../utils/getAdminLanguage.js'
 
 const VF_KEYS = [
   'effectStyle',
@@ -126,7 +126,8 @@ export default function StylePresetField(props: TextFieldClientProps) {
   const { path } = props
   const { value: selectedPreset, setValue } = useField<string>({ path })
   const { dispatchFields } = useForm()
-  const lang = getAdminLanguage() as 'en' | 'cs'
+  const lang = useThemeLanguage() as 'en' | 'cs'
+  const t = useThemeTranslations()
 
   const applyStylePreset = useCallback(
     (preset: StylePreset) => {
@@ -215,7 +216,10 @@ export default function StylePresetField(props: TextFieldClientProps) {
 
       {groupedPresets.map((category) => {
         const accent = CATEGORY_ACCENT[category.name] ?? '#64748b'
-        const catLabel = typeof category.label === 'object' ? category.label[lang] : category.label
+        const catLabel =
+          typeof category.label === 'object'
+            ? (category.label[lang] ?? category.label.en)
+            : category.label
         return (
           <div key={category.name} style={{ marginBottom: '20px' }}>
             {/* Category header */}
@@ -260,10 +264,12 @@ export default function StylePresetField(props: TextFieldClientProps) {
               {category.presets.map((preset) => {
                 const isSelected = selectedPreset === preset.name
                 const labelText =
-                  typeof preset.label === 'object' ? preset.label[lang] : preset.label
+                  typeof preset.label === 'object'
+                    ? (preset.label[lang] ?? preset.label.en)
+                    : preset.label
                 const descText =
                   typeof preset.description === 'object'
-                    ? preset.description[lang]
+                    ? (preset.description[lang] ?? preset.description.en)
                     : preset.description
                 const previewStyle = getPreviewStyle(preset)
                 const containerBg = getContainerBg(preset)
@@ -528,7 +534,7 @@ export default function StylePresetField(props: TextFieldClientProps) {
             transition: 'background 120ms ease',
           }}
         >
-          {lang === 'cs' ? '✕ Zrušit výběr' : '✕ Clear selection'}
+          {`✕ ${t.ui.clearSelection}`}
         </button>
       )}
     </div>

--- a/packages/theme-management/src/fields/ThemePreviewField.tsx
+++ b/packages/theme-management/src/fields/ThemePreviewField.tsx
@@ -13,9 +13,8 @@ import type {
 import { resolveTypographyPreview } from '../components/typographyPreviewUtils.js'
 import { allThemePresets } from '../index.js'
 import type { ThemePreset, ThemeTypographyPreset } from '../presets.js'
+import { useThemeTranslations } from '../hooks/useThemeTranslations.js'
 import { borderRadiusPresets } from '../providers/Theme/themeConfig.js'
-import { getTranslations } from '../translations.js'
-import { getAdminLanguage } from '../utils/getAdminLanguage.js'
 import { darkModeDefaults, lightModeDefaults } from './colorModeFields.js'
 
 // useLivePreviewContext is exported from @payloadcms/ui at runtime but TypeScript fails to resolve
@@ -83,7 +82,7 @@ interface ModePreviewProps {
 }
 
 function ModePreview({ icon: Icon, title, colors, typography, radius }: Readonly<ModePreviewProps>) {
-  const t = getTranslations(getAdminLanguage())
+  const t = useThemeTranslations()
   const background = colors.background ?? '#ffffff'
   const foreground = colors.foreground ?? '#0a0a0a'
   const borderColor = colors.border ?? 'rgba(148, 163, 184, 0.35)'
@@ -502,8 +501,8 @@ export default function ThemePreviewField(props: SelectFieldClientProps) {
     pill: borderRadiusCSS['--radius-xl'] ?? borderRadiusCSS['--radius-large'] ?? '999px',
   }
 
-  // Translate labels at runtime based on admin language
-  const t = getTranslations(getAdminLanguage())
+  // Translate labels at runtime based on the active Payload admin language
+  const t = useThemeTranslations()
   // Explicitly type keys as `keyof ColorModeColors` to satisfy TypeScript when indexing `lightMode`/`darkMode`
   const highlightSwatches: { key: keyof ColorModeColors; label: string }[] = [
     { key: 'primary', label: t.colors.primary },
@@ -554,13 +553,7 @@ export default function ThemePreviewField(props: SelectFieldClientProps) {
             }}
           >
             <span style={{ fontSize: '9px', lineHeight: 1 }}>{previewOpen ? '▼' : '▶'}</span>
-            {previewOpen
-              ? getAdminLanguage() === 'cs'
-                ? 'Skrýt náhled'
-                : 'Hide preview'
-              : getAdminLanguage() === 'cs'
-                ? 'Náhled'
-                : 'Preview'}
+            {previewOpen ? t.ui.hidePreview : t.ui.showPreview}
           </button>
         )}
       </div>
@@ -729,12 +722,10 @@ export default function ThemePreviewField(props: SelectFieldClientProps) {
                     "Effects & components" preview (AppearancePreviewField). */}
                 <span style={{ display: 'inline-flex', alignItems: 'center', gap: '6px' }}>
                   <Palette size={14} aria-hidden />
-                  {getAdminLanguage() === 'cs'
-                    ? 'Barvy & typografie'
-                    : 'Colours & typography'}
+                  {t.ui.colorsAndTypography}
                 </span>
                 <span style={{ fontSize: '12px', color: 'var(--theme-elevation-600)' }}>
-                  {activePreset ? activePreset.label : getTranslations('en').preview.customPalette}
+                  {activePreset ? activePreset.label : t.preview.customPalette}
                 </span>
               </div>
 
@@ -746,14 +737,14 @@ export default function ThemePreviewField(props: SelectFieldClientProps) {
               >
                 <ModePreview
                   icon={Sun}
-                  title={getTranslations('en').ui.lightMode}
+                  title={t.ui.lightMode}
                   colors={lightModeColors}
                   typography={previewTypography}
                   radius={previewRadius}
                 />
                 <ModePreview
                   icon={Moon}
-                  title={getTranslations('en').ui.darkMode}
+                  title={t.ui.darkMode}
                   colors={darkModeColors}
                   typography={previewTypography}
                   radius={previewRadius}

--- a/packages/theme-management/src/fields/ThemeTokenSelectField.tsx
+++ b/packages/theme-management/src/fields/ThemeTokenSelectField.tsx
@@ -7,7 +7,7 @@ import { allThemePresets, fetchThemeConfiguration } from '../index.js'
 import type { SiteThemeConfiguration } from '../payload-types.js'
 import type { ThemePreset } from '../presets.js'
 import type { FetchThemeConfigurationOptions } from '../types.js'
-import { getAdminLanguage } from '../utils/getAdminLanguage.js'
+import { useThemeLanguage } from '../hooks/useThemeTranslations.js'
 import { inferTenant } from '../utils/inferTenant.js'
 import { resolveThemeConfiguration } from '../utils/resolveThemeConfiguration.js'
 
@@ -111,6 +111,8 @@ export default function ThemeTokenSelectField(props: SelectFieldClientProps) {
 
   const [options, setOptions] = useState<ThemeColorOption[]>(FALLBACK_TOKENS)
   const selectedValue = value || 'background'
+  // Active Payload admin language (reactive via Payload's i18n context).
+  const adminLang = useThemeLanguage()
 
   // Get themePresets from admin.custom or use defaults
   const themePresets = useMemo(() => {
@@ -155,9 +157,6 @@ export default function ThemeTokenSelectField(props: SelectFieldClientProps) {
     })()
 
     const inferredTenant = tenantFromForm ?? custom?.tenantSlug ?? inferTenant()
-
-    // Determine admin language to pass as `locale` to fetch, if not provided
-    const adminLang = getAdminLanguage()
 
     // Normalize fetch options so that even when callers provide an empty object ("{}"),
     // we still ensure `tenantSlug` and `locale` are set to sensible defaults (inferred/form/adminLang).
@@ -229,7 +228,7 @@ export default function ThemeTokenSelectField(props: SelectFieldClientProps) {
     return () => {
       controller.abort()
     }
-  }, [themePresets, field.admin?.custom, formThemeConfiguration, formTenant])
+  }, [themePresets, field.admin?.custom, formThemeConfiguration, formTenant, adminLang])
 
   const handleSelect = useCallback(
     (nextValue: string) => {
@@ -237,21 +236,6 @@ export default function ThemeTokenSelectField(props: SelectFieldClientProps) {
     },
     [setValue],
   )
-
-  // Make admin language reactive so switching admin UI language updates labels
-  const initialAdminLang = getAdminLanguage()
-  const [adminLang, setAdminLang] = useState<string>(initialAdminLang)
-
-  useEffect(() => {
-    if (typeof document === 'undefined' || !('MutationObserver' in window)) return
-    const el = document.documentElement
-    const obs = new MutationObserver(() => {
-      const next = getAdminLanguage()
-      if (next !== adminLang) setAdminLang(next)
-    })
-    obs.observe(el, { attributes: true, attributeFilter: ['lang'] })
-    return () => obs.disconnect()
-  }, [adminLang])
 
   const label =
     typeof field.label === 'string'

--- a/packages/theme-management/src/globals/ThemeSettings/FontPicker/FontPreview.tsx
+++ b/packages/theme-management/src/globals/ThemeSettings/FontPicker/FontPreview.tsx
@@ -2,8 +2,8 @@
 
 import React, { useEffect, useRef } from 'react'
 import type { GoogleFont } from '../../../app/api/google-fonts/route'
+import { useThemeLanguage } from '../../../hooks/useThemeTranslations.js'
 import { getTranslations } from '../../../translations.js'
-import { getAdminLanguage } from '../../../utils/getAdminLanguage.js'
 
 export type PreviewVariant =
   | 'h1'
@@ -34,6 +34,7 @@ export const FontPreview: React.FC<FontPreviewProps> = ({ font, variant, text, o
   const shadowHostRef = useRef<HTMLDivElement>(null)
   const shadowRootRef = useRef<ShadowRoot | null>(null)
   const fontLoadedRef = useRef(false)
+  const adminLang = useThemeLanguage()
 
   useEffect(() => {
     if (!shadowHostRef.current) return
@@ -90,7 +91,7 @@ export const FontPreview: React.FC<FontPreviewProps> = ({ font, variant, text, o
       `
 
       let content: HTMLElement
-      const t = getTranslations(getAdminLanguage())
+      const t = getTranslations(adminLang)
 
       switch (variant) {
         case 'h1':
@@ -267,7 +268,7 @@ export const FontPreview: React.FC<FontPreviewProps> = ({ font, variant, text, o
         shadowRoot.innerHTML = ''
       }
     }
-  }, [font, variant, text, onLoad])
+  }, [font, variant, text, onLoad, adminLang])
 
   return <div ref={shadowHostRef} style={{ width: '100%', minHeight: '20px' }} />
 }

--- a/packages/theme-management/src/globals/ThemeSettings/FontPicker/index.tsx
+++ b/packages/theme-management/src/globals/ThemeSettings/FontPicker/index.tsx
@@ -8,9 +8,10 @@ import type {
   GoogleFont,
   LanguageSubset,
 } from '../../../app/api/google-fonts/route.js'
+import { useThemeLanguage } from '../../../hooks/useThemeTranslations.js'
 import { FontPreview } from './FontPreview.js'
 import { PreviewContent, type PreviewTab } from './PreviewContent.js'
-import { getTranslations, type Language } from './translations.js'
+import { getTranslations, translations, type Language } from './translations.js'
 
 // Import CSS for styling
 if (typeof window !== 'undefined') {
@@ -38,7 +39,9 @@ export interface FontPickerProps {
 const FontPickerField: React.FC<TextFieldClientProps> = (props) => {
   const { path } = props
   const { value, setValue } = useField<string>({ path })
-  const language: Language = 'en' // Could be extracted from admin config
+  const adminLang = useThemeLanguage()
+  // FontPicker ships its own en/cs strings; fall back to English for any other locale.
+  const language: Language = adminLang in translations ? (adminLang as Language) : 'en'
 
   const handleChange = useCallback(
     (fontFamily: string) => {

--- a/packages/theme-management/src/hooks/useThemeTranslations.ts
+++ b/packages/theme-management/src/hooks/useThemeTranslations.ts
@@ -1,0 +1,25 @@
+'use client'
+
+import { useTranslation } from '@payloadcms/ui'
+import { getTranslations, type PluginTranslations } from '../translations.js'
+
+/**
+ * Resolve the current Payload admin language using Payload's native i18n context
+ * (instead of sniffing `navigator.language`). Falls back to English.
+ */
+export function useThemeLanguage(): string {
+  // Tolerate `useTranslation()` returning undefined (e.g. outside an i18n provider
+  // or in unit tests with reset mocks) by falling back to English.
+  const result = useTranslation() as { i18n?: { language?: string } } | undefined
+  const language = result?.i18n?.language
+  return typeof language === 'string' && language.length >= 2 ? language : 'en'
+}
+
+/**
+ * Return the plugin's translations for the active admin language, with English
+ * used as the fallback for any missing key. Use this in client field components
+ * so the strings follow the admin's selected locale natively.
+ */
+export function useThemeTranslations(): PluginTranslations {
+  return getTranslations(useThemeLanguage())
+}

--- a/packages/theme-management/src/i18n.ts
+++ b/packages/theme-management/src/i18n.ts
@@ -1,0 +1,105 @@
+import type { Config } from 'payload'
+import {
+  THEME_MANAGEMENT_I18N_NAMESPACE,
+  availableLanguages,
+  deepMerge,
+  getTranslations,
+  registerTranslations,
+  type DeepPartial,
+  type PluginTranslations,
+} from './translations.js'
+
+/**
+ * Additional or overriding translations, keyed by language code.
+ * Each entry is deep-merged over the built-in English/Czech translations, so you
+ * only need to provide the keys you want to add or change.
+ */
+export type ThemeManagementI18nTranslations = Record<string, DeepPartial<PluginTranslations>>
+
+export interface ThemeManagementI18nOptions {
+  /**
+   * Extra languages or per-key overrides for the plugin admin UI strings.
+   *
+   * @example
+   * i18n: {
+   *   translations: {
+   *     de: { tabLabel: 'Darstellung', ui: { lightMode: 'Heller Modus' } },
+   *     en: { tabLabel: 'Theme' }, // override a built-in string
+   *   },
+   * }
+   */
+  translations?: ThemeManagementI18nTranslations
+  /**
+   * Pass-through to `config.i18n.supportedLanguages`. Provide language objects from
+   * `@payloadcms/translations/languages/*` when you want the Payload admin to offer a
+   * brand-new admin language (beyond the project defaults).
+   *
+   * @example
+   * import { de } from '@payloadcms/translations/languages/de'
+   * i18n: { supportedLanguages: { de } }
+   */
+  supportedLanguages?: Record<string, unknown>
+}
+
+type PayloadTranslationsByLang = Record<string, Record<string, unknown>>
+
+/**
+ * Build the plugin's translations in Payload's native `config.i18n.translations`
+ * shape: `{ [lang]: { 'theme-management': { ...keys } } }`.
+ *
+ * Every language is filled out via `getTranslations`, so English acts as the
+ * fallback for any missing key in another language.
+ */
+export function getThemeManagementI18nTranslations(): PayloadTranslationsByLang {
+  const out: PayloadTranslationsByLang = {}
+  for (const lang of availableLanguages()) {
+    out[lang] = { [THEME_MANAGEMENT_I18N_NAMESPACE]: getTranslations(lang) }
+  }
+  return out
+}
+
+/**
+ * Merge the plugin's translations into an existing `config.i18n`, following the
+ * official Payload plugin i18n pattern. Translations already present on the
+ * incoming config win over the plugin defaults, so apps can freely override.
+ *
+ * Any `options.translations` are registered first so they participate in the
+ * merge (and are visible to `getTranslations` at runtime), and any
+ * `options.supportedLanguages` are passed straight through.
+ */
+export function mergeThemeManagementI18n(
+  existing: Config['i18n'],
+  options?: ThemeManagementI18nOptions,
+): NonNullable<Config['i18n']> {
+  if (options?.translations) {
+    registerTranslations(options.translations)
+  }
+
+  const pluginTranslations = getThemeManagementI18nTranslations()
+  const existingTranslations = (existing?.translations ?? {}) as PayloadTranslationsByLang
+
+  // Start from existing translations to preserve every other namespace/language,
+  // then layer the plugin namespace underneath the app's own values.
+  const mergedTranslations: PayloadTranslationsByLang = { ...existingTranslations }
+  for (const lang of Object.keys(pluginTranslations)) {
+    mergedTranslations[lang] = deepMerge(
+      pluginTranslations[lang] as Record<string, unknown>,
+      (existingTranslations[lang] ?? {}) as Record<string, unknown>,
+    )
+  }
+
+  const merged = {
+    ...(existing ?? {}),
+    translations: mergedTranslations,
+  } as NonNullable<Config['i18n']>
+
+  if (options?.supportedLanguages) {
+    ;(merged as { supportedLanguages?: Record<string, unknown> }).supportedLanguages = {
+      ...((existing as { supportedLanguages?: Record<string, unknown> } | undefined)
+        ?.supportedLanguages ?? {}),
+      ...options.supportedLanguages,
+    }
+  }
+
+  return merged
+}

--- a/packages/theme-management/src/index.ts
+++ b/packages/theme-management/src/index.ts
@@ -5,6 +5,7 @@ import type { ThemeTab } from './fields/themeConfigurationField.js'
 import type { SiteThemeConfiguration } from './payload-types.js'
 import type { ThemePreset } from './presets.js'
 import { allThemePresets } from './presets.js'
+import { mergeThemeManagementI18n } from './i18n.js'
 import { getTranslations, translations } from './translations.js'
 import type {
   FetchThemeConfigurationOptions,
@@ -660,6 +661,7 @@ export const themeManagementPlugin = (options: ThemeManagementPluginOptions = {}
       enableLogging = false,
       livePreview = true,
       cacheRevalidation,
+      i18n,
     } = options
 
     const normalizedLivePreview = normalizeLivePreviewOptions(livePreview)
@@ -674,6 +676,14 @@ export const themeManagementPlugin = (options: ThemeManagementPluginOptions = {}
         console.log('Theme Management Plugin: disabled via options, skipping.')
       }
       return config
+    }
+
+    // Register the plugin's translations into Payload's native i18n
+    // (`theme-management` namespace), merging in any user-provided extensions or
+    // overrides. This config is used as the base for every return path below.
+    const configWithI18n: Config = {
+      ...config,
+      i18n: mergeThemeManagementI18n(config.i18n, i18n),
     }
 
     const themeTab = createThemeConfigurationField({
@@ -789,7 +799,7 @@ export const themeManagementPlugin = (options: ThemeManagementPluginOptions = {}
         },
       }
 
-      const globals = Array.isArray(config.globals) ? config.globals : []
+      const globals = Array.isArray(configWithI18n.globals) ? configWithI18n.globals : []
 
       // Check if global already exists
       const existingIndex = globals.findIndex((g) => g.slug === standaloneCollectionSlug)
@@ -800,10 +810,10 @@ export const themeManagementPlugin = (options: ThemeManagementPluginOptions = {}
             `Theme Management Plugin: global "${standaloneCollectionSlug}" already exists, skipping creation.`,
           )
         }
-        return config
+        return configWithI18n
       }
 
-      const currentEndpoints = ensureEndpointsArray(config.endpoints)
+      const currentEndpoints = ensureEndpointsArray(configWithI18n.endpoints)
       const livePreviewEndpoint = createLivePreviewEndpoint({
         livePreview: normalizedLivePreview,
         enableLogging,
@@ -816,7 +826,7 @@ export const themeManagementPlugin = (options: ThemeManagementPluginOptions = {}
       endpoints = mergeEndpoint(endpoints, cacheEndpoint)
 
       return {
-        ...config,
+        ...configWithI18n,
         endpoints,
         globals: [...globals, standaloneGlobal],
       }
@@ -825,7 +835,7 @@ export const themeManagementPlugin = (options: ThemeManagementPluginOptions = {}
     // Otherwise, add as tab to existing collection
     let collectionTouched = false
 
-    const collections = ensureCollectionsArray(config.collections).map((collection) => {
+    const collections = ensureCollectionsArray(configWithI18n.collections).map((collection) => {
       if (collection.slug !== targetCollection) {
         return collection
       }
@@ -858,10 +868,10 @@ export const themeManagementPlugin = (options: ThemeManagementPluginOptions = {}
           `Theme Management Plugin: collection "${targetCollection}" was not found, leaving config untouched.`,
         )
       }
-      return config
+      return configWithI18n
     }
 
-    const currentEndpoints = ensureEndpointsArray(config.endpoints)
+    const currentEndpoints = ensureEndpointsArray(configWithI18n.endpoints)
     const livePreviewEndpoint = createLivePreviewEndpoint({
       livePreview: normalizedLivePreview,
       enableLogging,
@@ -874,7 +884,7 @@ export const themeManagementPlugin = (options: ThemeManagementPluginOptions = {}
     endpoints = mergeEndpoint(endpoints, cacheEndpoint)
 
     return {
-      ...config,
+      ...configWithI18n,
       endpoints,
       collections,
     }
@@ -1054,6 +1064,18 @@ export {
   getTranslations,
   registerTranslations,
   availableLanguages,
+  THEME_MANAGEMENT_I18N_NAMESPACE,
 } from './translations.js'
+export type { PluginTranslations, Language, DeepPartial } from './translations.js'
+
+// Native Payload i18n helpers (theme-management namespace)
+export {
+  mergeThemeManagementI18n,
+  getThemeManagementI18nTranslations,
+} from './i18n.js'
+export type {
+  ThemeManagementI18nOptions,
+  ThemeManagementI18nTranslations,
+} from './i18n.js'
 
 export default themeManagementPlugin

--- a/packages/theme-management/src/translations.ts
+++ b/packages/theme-management/src/translations.ts
@@ -1,5 +1,12 @@
 export type Language = string
 
+/**
+ * i18n namespace under which all plugin translations are registered inside
+ * Payload's `config.i18n.translations`. Consumers can reference keys via
+ * `t('theme-management:...')` and override them by merging into the same namespace.
+ */
+export const THEME_MANAGEMENT_I18N_NAMESPACE = 'theme-management' as const
+
 export interface PluginTranslations {
   tabLabel: string
   standaloneCollectionLabel: string
@@ -16,6 +23,10 @@ export interface PluginTranslations {
     usePreset: string
     specifyCustom: string
     sampleSentence: string
+    showPreview: string
+    hidePreview: string
+    colorsAndTypography: string
+    clearSelection: string
   }
   colors: {
     primary: string
@@ -61,6 +72,10 @@ const translations: Record<Language, PluginTranslations> = {
       usePreset: 'Use theme preset font',
       specifyCustom: 'Specify custom font below',
       sampleSentence: 'The quick brown fox jumps over the lazy dog',
+      showPreview: 'Preview',
+      hidePreview: 'Hide preview',
+      colorsAndTypography: 'Colours & typography',
+      clearSelection: 'Clear selection',
     },
     colors: {
       primary: 'Primary',
@@ -104,6 +119,10 @@ const translations: Record<Language, PluginTranslations> = {
       usePreset: 'Použít písmo motivu',
       specifyCustom: 'Zadejte vlastní písmo níže',
       sampleSentence: 'Rychlá hnědá liška přeskočila líného psa',
+      showPreview: 'Náhled',
+      hidePreview: 'Skrýt náhled',
+      colorsAndTypography: 'Barvy & typografie',
+      clearSelection: 'Zrušit výběr',
     },
     colors: {
       primary: 'Primární',
@@ -133,11 +152,11 @@ const translations: Record<Language, PluginTranslations> = {
   },
 }
 
-type DeepPartial<T> = {
+export type DeepPartial<T> = {
   [P in keyof T]?: T[P] extends object ? DeepPartial<T[P]> : T[P]
 }
 
-function deepMerge<T extends object>(base: T, partial: DeepPartial<T>): T {
+export function deepMerge<T extends object>(base: T, partial: DeepPartial<T>): T {
   const out: Record<string, unknown> = { ...(base as Record<string, unknown>) }
   for (const key of Object.keys(partial)) {
     const val = (partial as Record<string, unknown>)[key]
@@ -160,14 +179,11 @@ export function getTranslations(lang: Language = 'en'): PluginTranslations {
 }
 
 export function registerTranslations(
-  newTranslations: Record<Language, Partial<PluginTranslations>>,
+  newTranslations: Record<Language, DeepPartial<PluginTranslations>>,
 ) {
   for (const lang of Object.keys(newTranslations)) {
     const existing = (translations[lang] as PluginTranslations) || ({} as PluginTranslations)
-    translations[lang] = deepMerge(
-      existing,
-      newTranslations[lang] as DeepPartial<PluginTranslations>,
-    )
+    translations[lang] = deepMerge(existing, newTranslations[lang])
   }
 }
 

--- a/packages/theme-management/src/types.ts
+++ b/packages/theme-management/src/types.ts
@@ -1,5 +1,8 @@
 import type { Field } from 'payload'
+import type { ThemeManagementI18nOptions } from './i18n.js'
 import type { ThemePreset } from './presets.js'
+
+export type { ThemeManagementI18nOptions, ThemeManagementI18nTranslations } from './i18n.js'
 
 export interface ThemeManagementLivePreviewUrlArgs {
   /** Resolved preview page document (if found) */
@@ -109,6 +112,13 @@ export interface ThemeManagementPluginOptions {
   livePreview?: boolean | ThemeManagementLivePreviewOptions
   /** Configure cache revalidation route and tags for Next.js `unstable_cache` usage */
   cacheRevalidation?: boolean | ThemeManagementCacheRevalidationOptions
+  /**
+   * Extend or override the plugin's admin i18n. Built-in languages are English (`en`)
+   * and Czech (`cs`); add more or override individual strings here. Translations are
+   * merged into Payload's native `config.i18n.translations` under the
+   * `theme-management` namespace.
+   */
+  i18n?: ThemeManagementI18nOptions
 }
 
 export interface FetchThemeConfigurationOptions {

--- a/packages/theme-management/src/types/payload-ui.d.ts
+++ b/packages/theme-management/src/types/payload-ui.d.ts
@@ -10,4 +10,8 @@ declare module '@payloadcms/ui' {
   export function useField<T = any>(opts: any): { value: T; setValue: (v: T) => void }
   export function useForm(): any
   export function useFormFields<T = any>(selector?: (args: any) => T): T
+  export function useTranslation(): {
+    t: (key: string, options?: Record<string, unknown>) => string
+    i18n: { language: string; [key: string]: any }
+  }
 }

--- a/packages/theme-management/tests/unit/ThemePreviewField.test.tsx
+++ b/packages/theme-management/tests/unit/ThemePreviewField.test.tsx
@@ -20,6 +20,10 @@ jest.mock('@payloadcms/ui', () => ({
     isLivePreviewEnabled: undefined,
     isLivePreviewing: undefined,
   })),
+  useTranslation: jest.fn(() => ({
+    t: (key: string) => key,
+    i18n: { language: 'en' },
+  })),
 }))
 
 jest.mock('../../src/components/typographyPreviewUtils.js', () => ({

--- a/packages/theme-management/tests/unit/ThemeTokenSelectField.test.tsx
+++ b/packages/theme-management/tests/unit/ThemeTokenSelectField.test.tsx
@@ -11,6 +11,10 @@ jest.mock('@payloadcms/ui', () => ({
     if (path === 'themeConfiguration') return { value: null }
     return { value: undefined, setValue: mockSetValue }
   }),
+  useTranslation: jest.fn(() => ({
+    t: (key: string) => key,
+    i18n: { language: 'en' },
+  })),
 }))
 
 jest.mock('../../src/index.js', () => ({

--- a/packages/theme-management/tests/unit/i18n-native.test.ts
+++ b/packages/theme-management/tests/unit/i18n-native.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from '@jest/globals'
+import { themeManagementPlugin } from '../../src/index.js'
+import {
+  getThemeManagementI18nTranslations,
+  mergeThemeManagementI18n,
+} from '../../src/i18n.js'
+import { THEME_MANAGEMENT_I18N_NAMESPACE } from '../../src/translations.js'
+
+const NS = THEME_MANAGEMENT_I18N_NAMESPACE
+
+describe('Theme Management - native Payload i18n', () => {
+  it('exposes built-in en + cs translations under the plugin namespace', () => {
+    const translations = getThemeManagementI18nTranslations()
+
+    expect(Object.keys(translations)).toEqual(expect.arrayContaining(['en', 'cs']))
+    expect((translations.en[NS] as any).tabLabel).toBe('Appearance Settings')
+    expect((translations.cs[NS] as any).tabLabel).toBe('Nastavení vzhledu')
+  })
+
+  it('merges plugin translations into an existing config.i18n while preserving other namespaces', () => {
+    const existing = {
+      translations: {
+        en: { general: { cancel: 'Cancel' } },
+      },
+    } as any
+
+    const merged = mergeThemeManagementI18n(existing) as any
+
+    // Existing namespace is preserved
+    expect(merged.translations.en.general.cancel).toBe('Cancel')
+    // Plugin namespace is added
+    expect(merged.translations.en[NS].tabLabel).toBe('Appearance Settings')
+    // New language from the plugin is added
+    expect(merged.translations.cs[NS].tabLabel).toBe('Nastavení vzhledu')
+  })
+
+  it('lets the incoming config override plugin defaults on conflict', () => {
+    const existing = {
+      translations: {
+        en: { [NS]: { tabLabel: 'My Custom Label' } },
+      },
+    } as any
+
+    const merged = mergeThemeManagementI18n(existing) as any
+
+    expect(merged.translations.en[NS].tabLabel).toBe('My Custom Label')
+    // Untouched keys still fall back to the plugin defaults
+    expect(merged.translations.en[NS].ui.lightMode).toBe('Light Mode')
+  })
+
+  it('passes supportedLanguages through to config.i18n', () => {
+    const fakeDe = { __lang: 'de' }
+    const merged = mergeThemeManagementI18n(
+      { supportedLanguages: { en: { __lang: 'en' } } } as any,
+      { supportedLanguages: { de: fakeDe } },
+    ) as any
+
+    expect(merged.supportedLanguages.de).toBe(fakeDe)
+    expect(merged.supportedLanguages.en).toEqual({ __lang: 'en' })
+  })
+
+  it('registers the namespace on config.i18n when the plugin runs', () => {
+    const mockConfig: any = {
+      collections: [{ slug: 'site-settings', fields: [] }],
+      globals: [],
+    }
+
+    const result = themeManagementPlugin({ enableLogging: false })(mockConfig) as any
+
+    expect(result.i18n.translations.en[NS].tabLabel).toBe('Appearance Settings')
+    expect(result.i18n.translations.cs[NS].tabLabel).toBe('Nastavení vzhledu')
+  })
+
+  it('applies the plugin i18n option end-to-end', () => {
+    const mockConfig: any = {
+      collections: [{ slug: 'site-settings', fields: [] }],
+      globals: [],
+    }
+
+    const result = themeManagementPlugin({
+      enableLogging: false,
+      i18n: {
+        translations: {
+          fr: { tabLabel: 'Apparence' },
+        },
+      },
+    })(mockConfig) as any
+
+    expect(result.i18n.translations.fr[NS].tabLabel).toBe('Apparence')
+    // English fallback for untranslated keys in the new language
+    expect(result.i18n.translations.fr[NS].ui.darkMode).toBe('Dark Mode')
+  })
+
+  // NOTE: kept last — `registerTranslations` mutates the shared runtime registry,
+  // so overriding a built-in language here would otherwise leak into other tests.
+  it('accepts extra languages and per-key overrides via the i18n option', () => {
+    const merged = mergeThemeManagementI18n(undefined, {
+      translations: {
+        de: { tabLabel: 'Darstellung', ui: { lightMode: 'Heller Modus' } },
+        en: { tabLabel: 'Theme' },
+      },
+    }) as any
+
+    // Brand-new language
+    expect(merged.translations.de[NS].tabLabel).toBe('Darstellung')
+    expect(merged.translations.de[NS].ui.lightMode).toBe('Heller Modus')
+    // Missing keys in the new language fall back to English
+    expect(merged.translations.de[NS].ui.darkMode).toBe('Dark Mode')
+    // Override of a built-in string
+    expect(merged.translations.en[NS].tabLabel).toBe('Theme')
+  })
+})


### PR DESCRIPTION
Register plugin translations into Payload's native config.i18n under the
'theme-management' namespace and make them extensible through the plugin
configuration.

- Add mergeThemeManagementI18n / getThemeManagementI18nTranslations helpers
  and wire them into the plugin so config.i18n is populated on every return path
- Add i18n plugin option (translations + supportedLanguages) for adding
  languages or overriding individual strings (deep-merged, English fallback)
- Add useThemeTranslations / useThemeLanguage client hooks that resolve the
  active admin language via Payload's i18n context, replacing navigator sniffing
- Convert ThemePreviewField, FontSelectField, StylePresetField,
  AppearancePreviewField, ThemeTokenSelectField and the FontPicker to the hooks
- Export i18n helpers/types and a ./hooks/* subpath; document in README + docs
- Add native i18n unit tests; update existing client-field test mocks

https://claude.ai/code/session_01PcwnVNnbrbgRo8B3tdnJJy